### PR TITLE
Add missing -U argument to pip-compile

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,4 +35,4 @@ labels = pip-compile
 deps =
     pip-tools
 commands =
-    pip-compile --generate-hashes test-requirements.in -o test-requirements-{basepython}.txt
+    pip-compile -U --generate-hashes test-requirements.in -o test-requirements-{basepython}.txt


### PR DESCRIPTION
It will not actually update dependencies if this is missing.