### PR TITLE
Accept buffered IO stream objects as fd in hdrFromFdno

### DIFF
--- a/src/rpmdyn/_transaction.py
+++ b/src/rpmdyn/_transaction.py
@@ -1,3 +1,5 @@
+from io import IOBase
+
 from ._ffi import gc, cstr
 from . import _ffi, _const
 
@@ -111,6 +113,11 @@ class TransactionSet(object):
         return _ffi.rpmtsVSFlags(self.__ts)
 
     def hdrFromFdno(self, fd):
+        # Accept the Buffered I/O stream object as fd. It inherits IOBase
+        # the proides the underlying FD number where available.
+        if isinstance(fd, IOBase):
+            fd = fd.fileno()
+
         assert isinstance(fd, int)
 
         rpmfd = _ffi.fdDup(fd)


### PR DESCRIPTION
One of the tests for rcm-pa-tool failed with below error that previously worked with rpm-py-installer.
```
rcm_pa_tool/pa_chains/upload_rpm_to_repo.py:19: in call
    hdr = ts.hdrFromFdno(fdno)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <rpmdyn._transaction.TransactionSet object at 0x7f02ffefc650>
fd = <_io.BufferedReader name='tests/test_data/pulp-test-package-0.3.1-1.fc11.x86_64.rpm'>

    def hdrFromFdno(self, fd):
>       assert isinstance(fd, int)
E       AssertionError
```
fd arg to hdrFromFdno might be a buffered IO stream object like the one returned by open() as mentioed above. As rpm.transaction.hdrFromFdno accepts the buffered IO object as fd, the same method here should accept the object as well.