### PR TITLE
Undo reusable pypi publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,48 @@ on:
     branches: [main]
 
 jobs:
-  tests:
+  run-ci:
     uses: ./.github/workflows/tox.yml
 
   pypi-publish:
-    needs: [tests]
+    name: Upload release to PyPI
+    needs: [run-ci]
+    runs-on: ubuntu-22.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rpmdyn
     permissions:
       id-token: write
-    uses: rohanpm/workflows/.github/workflows/pypi-release.yml@main
-    with:
-      name: rpmdyn
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install build
+
+      - name: Build distribution
+        run: |
+          python -mbuild
+
+      - name: Prepare for wheel check
+        run: |
+          pip download --no-deps --only-binary :all: --implementation py --platform none rpmdyn
+          pip install wheeldiff
+
+      - name: Check if wheel content changed
+        id: wheeldiff
+        run: |
+          set +e
+          set -x
+          wheeldiff --ignore version,record *.whl dist/*.whl
+          echo "diff=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: steps.wheeldiff.outputs.diff == '2'


### PR DESCRIPTION
Per [1], reusable workflows cannot be used with trusted publishers.

[1] https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github